### PR TITLE
Fixes request method used by Search

### DIFF
--- a/search.go
+++ b/search.go
@@ -19,7 +19,7 @@ type SearchResults struct {
 func Search(siteId string, opts SearchOptions) (*SearchResults, error) {
 	url := fmt.Sprintf("https://%s.craigslist.org/search/%s", siteId, opts.Category)
 
-	req, err := http.NewRequest("get", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Search previously used `"get"` as the HTTP method, which led to the
error:

> net/http: HTTP/1.x transport connection broken: unexpected EOF

Updates the method to `"GET"` by using the constant `MethodGet` from
net/http.